### PR TITLE
Return an error from the Fetch interface

### DIFF
--- a/httplimit/middleware.go
+++ b/httplimit/middleware.go
@@ -98,7 +98,12 @@ func (m *Middleware) Handle(next http.Handler) http.Handler {
 		}
 
 		// Take from the store.
-		limit, remaining, reset, ok := m.store.Take(key)
+		limit, remaining, reset, ok, err := m.store.Take(key)
+		if err != nil {
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+
 		resetTime := time.Unix(0, int64(reset)).UTC().Format(time.RFC1123)
 
 		// Set headers (we do this regardless of whether the request is permitted).

--- a/memorystore/example_test.go
+++ b/memorystore/example_test.go
@@ -17,6 +17,9 @@ func ExampleNew() {
 	}
 	defer store.Close()
 
-	limit, remaining, reset, ok := store.Take("my-key")
+	limit, remaining, reset, ok, err := store.Take("my-key")
+	if err != nil {
+		log.Fatal(err)
+	}
 	_, _, _, _ = limit, remaining, reset, ok
 }

--- a/noopstore/example_test.go
+++ b/noopstore/example_test.go
@@ -13,6 +13,9 @@ func ExampleNew() {
 	}
 	defer store.Close()
 
-	limit, remaining, reset, ok := store.Take("my-key")
+	limit, remaining, reset, ok, err := store.Take("my-key")
+	if err != nil {
+		log.Fatal(err)
+	}
 	_, _, _, _ = limit, remaining, reset, ok
 }

--- a/noopstore/store.go
+++ b/noopstore/store.go
@@ -13,8 +13,8 @@ func New() (limiter.Store, error) {
 }
 
 // Take always allows the request.
-func (s *store) Take(_ string) (uint64, uint64, uint64, bool) {
-	return 0, 0, 0, true
+func (s *store) Take(_ string) (uint64, uint64, uint64, bool, error) {
+	return 0, 0, 0, true, nil
 }
 
 // Close does nothing.

--- a/redisstore/example_test.go
+++ b/redisstore/example_test.go
@@ -28,6 +28,9 @@ func ExampleNew() {
 	}
 	defer store.Close()
 
-	limit, remaining, reset, ok := store.Take("my-key")
+	limit, remaining, reset, ok, err := store.Take("my-key")
+	if err != nil {
+		log.Fatal(err)
+	}
 	_, _, _, _ = limit, remaining, reset, ok
 }

--- a/redisstore/store_test.go
+++ b/redisstore/store_test.go
@@ -84,14 +84,15 @@ func TestStore_Take(t *testing.T) {
 				limit, remaining uint64
 				reset            time.Duration
 				ok               bool
+				err              error
 			}
 
 			// Take twice everything
 			takeCh := make(chan *result, 2*tc.tokens)
 			for i := uint64(1); i <= 2*tc.tokens; i++ {
 				go func() {
-					limit, remaining, reset, ok := s.Take(key)
-					takeCh <- &result{limit, remaining, time.Until(time.Unix(0, int64(reset))), ok}
+					limit, remaining, reset, ok, err := s.Take(key)
+					takeCh <- &result{limit, remaining, time.Until(time.Unix(0, int64(reset))), ok, err}
 				}()
 			}
 
@@ -113,6 +114,10 @@ func TestStore_Take(t *testing.T) {
 			})
 
 			for i, result := range results {
+				if err := result.err; err != nil {
+					t.Fatal(err)
+				}
+
 				if got, want := result.limit, tc.tokens; got != want {
 					t.Errorf("limit: expected %d to be %d", got, want)
 				}
@@ -142,7 +147,11 @@ func TestStore_Take(t *testing.T) {
 			time.Sleep(tc.interval)
 
 			// Verify we can take once more
-			if _, _, _, ok := s.Take(key); !ok {
+			_, _, _, ok, err := s.Take(key)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !ok {
 				t.Errorf("expected %t to be %t", ok, true)
 			}
 		})

--- a/store.go
+++ b/store.go
@@ -1,6 +1,11 @@
 package limiter
 
-import "io"
+import (
+	"fmt"
+	"io"
+)
+
+var ErrStopped = fmt.Errorf("store is stopped")
 
 // Store is an interface for limiter storage backends.
 //
@@ -19,12 +24,15 @@ type Store interface {
 	// - the number of remaining tokens in the interval
 	// - the server time when new tokens will be available
 	// - whether the take was successful
+	// - any errors that occurred while performing the take - these should be
+	//   backend errors (e.g. connection failures); Take() should never return an
+	//   error for an bucket.
 	//
 	// If "ok" is false, the take was unsuccessful and the caller should NOT
 	// service the request.
 	//
 	// See the note about keys on the interface documentation.
-	Take(key string) (limit, remaining, reset uint64, ok bool)
+	Take(key string) (limit, remaining, reset uint64, ok bool, err error)
 
 	// Close terminates the store and cleans up any data structures or connections
 	// that may remain open. After a store is stopped, Take() should always return


### PR DESCRIPTION
This is a BREAKING CHANGE that allows implementers to return an error (such as connection failure) from Take, separate from the "ok" boolean.