### PR TITLE
Make store multi-tenant

### DIFF
--- a/benchmarks/go.mod
+++ b/benchmarks/go.mod
@@ -4,8 +4,9 @@ go 1.14
 
 require (
 	github.com/didip/tollbooth/v6 v6.0.1
+	github.com/gomodule/redigo v1.8.2
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
-	github.com/sethvargo/go-limiter v0.3.2-0.20200818185929-f9ab9053588b
+	github.com/sethvargo/go-limiter v0.4.1
 	github.com/sethvargo/go-redisstore v0.1.0
 	github.com/throttled/throttled v2.2.4+incompatible
 	github.com/ulule/limiter/v3 v3.5.0

--- a/httplimit/middleware.go
+++ b/httplimit/middleware.go
@@ -62,13 +62,13 @@ func IPKeyFunc(headers ...string) KeyFunc {
 // rate limiting. It can rate limit based on an arbitrary KeyFunc, and supports
 // anything that implements limiter.StoreWithContext.
 type Middleware struct {
-	store   limiter.StoreWithContext
+	store   limiter.Store
 	keyFunc KeyFunc
 }
 
 // NewMiddleware creates a new middleware suitable for use as an HTTP handler.
 // This function returns an error if either the Store or KeyFunc are nil.
-func NewMiddleware(s limiter.StoreWithContext, f KeyFunc) (*Middleware, error) {
+func NewMiddleware(s limiter.Store, f KeyFunc) (*Middleware, error) {
 	if s == nil {
 		return nil, fmt.Errorf("store cannot be nil")
 	}
@@ -100,7 +100,7 @@ func (m *Middleware) Handle(next http.Handler) http.Handler {
 		}
 
 		// Take from the store.
-		limit, remaining, reset, ok, err := m.store.TakeWithContext(ctx, key)
+		limit, remaining, reset, ok, err := m.store.Take(ctx, key)
 		if err != nil {
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return

--- a/memorystore/example_test.go
+++ b/memorystore/example_test.go
@@ -1,6 +1,7 @@
 package memorystore_test
 
 import (
+	"context"
 	"log"
 	"time"
 
@@ -8,6 +9,8 @@ import (
 )
 
 func ExampleNew() {
+	ctx := context.Background()
+
 	store, err := memorystore.New(&memorystore.Config{
 		Tokens:   15,
 		Interval: time.Minute,
@@ -15,9 +18,9 @@ func ExampleNew() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer store.Close()
+	defer store.Close(ctx)
 
-	limit, remaining, reset, ok, err := store.Take("my-key")
+	limit, remaining, reset, ok, err := store.Take(ctx, "my-key")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/noopstore/example_test.go
+++ b/noopstore/example_test.go
@@ -1,19 +1,22 @@
 package noopstore_test
 
 import (
+	"context"
 	"log"
 
 	"github.com/sethvargo/go-limiter/noopstore"
 )
 
 func ExampleNew() {
+	ctx := context.Background()
+
 	store, err := noopstore.New()
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer store.Close()
+	defer store.Close(ctx)
 
-	limit, remaining, reset, ok, err := store.Take("my-key")
+	limit, remaining, reset, ok, err := store.Take(ctx, "my-key")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/noopstore/store.go
+++ b/noopstore/store.go
@@ -4,35 +4,30 @@ package noopstore
 
 import (
 	"context"
+	"time"
 
 	"github.com/sethvargo/go-limiter"
 )
 
 var _ limiter.Store = (*store)(nil)
-var _ limiter.StoreWithContext = (*store)(nil)
 
 type store struct{}
 
-func New() (limiter.StoreWithContext, error) {
+func New() (limiter.Store, error) {
 	return &store{}, nil
 }
 
 // Take always allows the request.
-func (s *store) Take(_ string) (uint64, uint64, uint64, bool, error) {
+func (s *store) Take(_ context.Context, _ string) (uint64, uint64, uint64, bool, error) {
 	return 0, 0, 0, true, nil
 }
 
-// TakeWithContext always allows the request.
-func (s *store) TakeWithContext(_ context.Context, _ string) (uint64, uint64, uint64, bool, error) {
-	return 0, 0, 0, true, nil
-}
-
-// Close does nothing.
-func (s *store) Close() error {
+// Set does nothing.
+func (s *store) Set(_ context.Context, _ string, _ uint64, _ time.Duration) error {
 	return nil
 }
 
-// CloseWithContext does nothing.
-func (s *store) CloseWithContext(_ context.Context) error {
+// Close does nothing.
+func (s *store) Close(_ context.Context) error {
 	return nil
 }


### PR DESCRIPTION
This is a breaking API change that enables per-key rate limits managed by the same store.

/cc @mikehelmick