### PR TITLE
Link to time.now instead of runtime

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
         - '1.14'
         - '1.15'
         - '1.16'
+        - '1.17'
         os:
         - 'macos-latest'
         - 'ubuntu-latest'

--- a/internal/fasttime/fasttime.go
+++ b/internal/fasttime/fasttime.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 // Package fasttime gets wallclock time, but super fast.
@@ -8,11 +9,12 @@ import (
 )
 
 //go:noescape
-//go:linkname nanotime runtime.nanotime
-func nanotime() int64
+//go:linkname now time.now
+func now() (sec int64, nsec int32, mono int64)
 
 // Now returns a monotonic clock value. The actual value will differ across
 // systems, but that's okay because we generally only care about the deltas.
 func Now() uint64 {
-	return uint64(nanotime())
+	sec, nsec, _ := now()
+	return uint64(sec)*1e9 + uint64(nsec)
 }


### PR DESCRIPTION
Fixes https://github.com/sethvargo/go-limiter/issues/27