### PR TITLE
Calling back the server time can cause an exception in the flow limit…

### DIFF
--- a/memorystore/store.go
+++ b/memorystore/store.go
@@ -306,6 +306,9 @@ func (b *bucket) take() (tokens uint64, remaining uint64, reset uint64, ok bool,
 	if b.lastTick < currTick {
 		b.availableTokens = b.maxTokens
 		b.lastTick = currTick
+	} else if currTick < 0 {
+		b.startTime = now
+		b.lastTick = 0
 	}
 
 	if b.availableTokens > 0 {


### PR DESCRIPTION
…ing mechanism

If the server time is adjusted back, we need to update the startTime of the bucket and reset the lastTick to 0