### PR TITLE
add newTick bool to get method

### DIFF
--- a/memorystore/store_test.go
+++ b/memorystore/store_test.go
@@ -68,7 +68,7 @@ func TestStore_Exercise(t *testing.T) {
 
 	// Get when no config exists
 	{
-		limit, remaining, err := s.(*store).Get(ctx, key)
+		limit, remaining, _, err := s.(*store).Get(ctx, key)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -103,7 +103,7 @@ func TestStore_Exercise(t *testing.T) {
 
 	// Get the value
 	{
-		limit, remaining, err := s.(*store).Get(ctx, key)
+		limit, remaining, _, err := s.(*store).Get(ctx, key)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -124,7 +124,7 @@ func TestStore_Exercise(t *testing.T) {
 
 	// Get the value again
 	{
-		limit, remaining, err := s.(*store).Get(ctx, key)
+		limit, remaining, _, err := s.(*store).Get(ctx, key)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -158,7 +158,7 @@ func TestStore_Exercise(t *testing.T) {
 
 	// Get the value again
 	{
-		limit, remaining, err := s.(*store).Get(ctx, key)
+		limit, remaining, _, err := s.(*store).Get(ctx, key)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -196,7 +196,7 @@ func TestStore_Exercise(t *testing.T) {
 
 	// Get the value one final time
 	{
-		limit, remaining, err := s.(*store).Get(ctx, key)
+		limit, remaining, _, err := s.(*store).Get(ctx, key)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/noopstore/store.go
+++ b/noopstore/store.go
@@ -23,8 +23,8 @@ func (s *store) Take(_ context.Context, _ string) (uint64, uint64, uint64, bool,
 }
 
 // Get does nothing.
-func (s *store) Get(_ context.Context, _ string) (uint64, uint64, error) {
-	return 0, 0, nil
+func (s *store) Get(_ context.Context, _ string) (uint64, uint64, bool, error) {
+	return 0, 0, false, nil
 }
 
 // Set does nothing.

--- a/store.go
+++ b/store.go
@@ -39,7 +39,7 @@ type Store interface {
 
 	// Get gets the current limit and remaining tokens for the provided key. It
 	// does not change any of the values.
-	Get(ctx context.Context, key string) (tokens, remaining uint64, err error)
+	Get(ctx context.Context, key string) (tokens, remaining uint64, newTick bool, err error)
 
 	// Set configures the limit at the provided key. If a limit already exists, it
 	// is overwritten. This also sets the number of tokens in the bucket to the


### PR DESCRIPTION
It might be useful when you create flow like: 
`_, remain, _ := store.Get()
if remain == 0 {
  return
}`
and only after
`store.Take()`


Because if you fill the bucket fast in interval, you will stuck and never go through remain condition, because remain reloading only in Take func. 
NewTick - resolve this issue, by modifing condition. 
`
if remain == 0 || !newTick {
`