### PR TITLE
Add benchmarks for clipperhouse/rate

### DIFF
--- a/benchmarks/clipperhouse_test.go
+++ b/benchmarks/clipperhouse_test.go
@@ -1,0 +1,60 @@
+package benchmarks
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/clipperhouse/rate"
+)
+
+func BenchmarkClipperhouseMemory(b *testing.B) {
+	cases := []struct {
+		name          string
+		tokens        uint64
+		interval      time.Duration
+		sweepInterval time.Duration
+		sweepMinTTL   time.Duration
+	}{
+		{
+			name:          "memory",
+			tokens:        math.MaxUint64,
+			interval:      time.Duration(math.MaxInt64),
+			sweepInterval: time.Duration(math.MaxInt64),
+			sweepMinTTL:   time.Duration(math.MaxInt64),
+		},
+	}
+
+	for _, tc := range cases {
+		keyFunc := func(i int) int {
+			return i % NumSessions
+		}
+		limit := rate.NewLimit(int64(tc.tokens), tc.interval)
+
+		b.Run(tc.name, func(b *testing.B) {
+			b.Run("serial", func(b *testing.B) {
+				limiter := rate.NewLimiter(keyFunc, limit)
+				b.ReportAllocs()
+				b.ResetTimer()
+
+				for i := 0; i < b.N; i++ {
+					limiter.Allow(i)
+				}
+				b.StopTimer()
+			})
+
+			b.Run("parallel", func(b *testing.B) {
+				limiter := rate.NewLimiter(keyFunc, limit)
+				b.ReportAllocs()
+				b.ResetTimer()
+
+				b.RunParallel(func(pb *testing.PB) {
+					for i := 0; pb.Next(); i++ {
+						limiter.Allow(i)
+					}
+				})
+				b.StopTimer()
+			})
+		})
+	}
+}

--- a/benchmarks/go.mod
+++ b/benchmarks/go.mod
@@ -1,16 +1,26 @@
 module github.com/sethvargo/go-limiter/benchmarks
 
-go 1.14
+go 1.24
+
+toolchain go1.24.6
 
 replace github.com/sethvargo/go-limiter => ../
 
 require (
+	github.com/clipperhouse/rate v0.2.0
 	github.com/didip/tollbooth/v6 v6.1.1
 	github.com/gomodule/redigo v1.8.5
-	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/sethvargo/go-limiter v0.6.0
 	github.com/sethvargo/go-redisstore v0.3.0
 	github.com/throttled/throttled v2.2.5+incompatible
 	github.com/ulule/limiter/v3 v3.8.0
 	go.uber.org/ratelimit v0.2.0
+)
+
+require (
+	github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 // indirect
+	github.com/go-pkgz/expirable-cache v0.0.3 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	golang.org/x/time v0.12.0 // indirect
 )

--- a/benchmarks/go.mod
+++ b/benchmarks/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.6
 replace github.com/sethvargo/go-limiter => ../
 
 require (
-	github.com/clipperhouse/rate v0.2.0
+	github.com/clipperhouse/rate v0.5.0
 	github.com/didip/tollbooth/v6 v6.1.1
 	github.com/gomodule/redigo v1.8.5
 	github.com/sethvargo/go-limiter v0.6.0
@@ -19,6 +19,7 @@ require (
 
 require (
 	github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 // indirect
+	github.com/clipperhouse/ntime v0.1.1 // indirect
 	github.com/go-pkgz/expirable-cache v0.0.3 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/benchmarks/go.sum
+++ b/benchmarks/go.sum
@@ -2,6 +2,8 @@ github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 h1:MzBOUgng9or
 github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129/go.mod h1:rFgpPQZYZ8vdbc+48xibu8ALc3yeyd64IhHS+PU6Yyg=
 github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/clipperhouse/rate v0.2.0 h1:JmilsQ2LE3QZS+lglBAWowqnAEG+Q6XOXVh6FrtwubM=
+github.com/clipperhouse/rate v0.2.0/go.mod h1:VZNuVghE/JjjFwv7gdQEhLAcqAp72zE6aiprfb4n7ew=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -40,10 +42,8 @@ github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uG
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/klauspost/compress v1.10.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
@@ -66,8 +66,9 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/throttled/throttled v2.2.5+incompatible h1:65UB52X0qNTYiT0Sohp8qLYVFwZQPDw85uSa65OljjQ=
 github.com/throttled/throttled v2.2.5+incompatible/go.mod h1:0BjlrEGQmvxps+HuXLsyRdqpSRvJpq0PNIsOtqP9Nos=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
@@ -103,8 +104,9 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1 h1:NusfzzA6yGQ+ua51ck7E3omNUX/JuqbFSaRGqU8CcLI=
 golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.12.0 h1:ScB/8o8olJvc+CQPWrK3fPZNfh7qgwCrY0zJmoEQLSE=
+golang.org/x/time v0.12.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
@@ -114,7 +116,6 @@ google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miE
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
@@ -122,5 +123,6 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/benchmarks/go.sum
+++ b/benchmarks/go.sum
@@ -2,8 +2,10 @@ github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 h1:MzBOUgng9or
 github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129/go.mod h1:rFgpPQZYZ8vdbc+48xibu8ALc3yeyd64IhHS+PU6Yyg=
 github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/clipperhouse/rate v0.2.0 h1:JmilsQ2LE3QZS+lglBAWowqnAEG+Q6XOXVh6FrtwubM=
-github.com/clipperhouse/rate v0.2.0/go.mod h1:VZNuVghE/JjjFwv7gdQEhLAcqAp72zE6aiprfb4n7ew=
+github.com/clipperhouse/ntime v0.1.1 h1:1nNgeCpB8e5IyiVvsJMhhynnnvstbD+MnmyTtdt7fBo=
+github.com/clipperhouse/ntime v0.1.1/go.mod h1:ltkB4V9vsTzh0x0qwOJPlxHHtAJJA4I+EJKjhbEktWY=
+github.com/clipperhouse/rate v0.5.0 h1:1meL91Sxtk6hL48IRU6NZ43J3NkS29q7yodFoJPnlk0=
+github.com/clipperhouse/rate v0.5.0/go.mod h1:rA+5DmDc7p4wVcb8HkZQ32tnkVyYJpkJOcaJVIbeAo4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Hi Seth! Nice work here. I am working on a new [Go rate limiter](https://github.com/clipperhouse/rate) and would like to add to your benchmarks.

My local run:

```
go test -bench=.
goos: darwin
goarch: arm64
pkg: github.com/sethvargo/go-limiter/benchmarks
cpu: Apple M2
BenchmarkClipperhouseMemory/memory/serial-8  	15701103	        76.72 ns/op	       0 B/op	       0 allocs/op
BenchmarkClipperhouseMemory/memory/parallel-8         	51872358	        21.91 ns/op	       0 B/op	       0 allocs/op
BenchmarkSethVargoMemory/memory/serial-8              	20293608	        58.64 ns/op
BenchmarkSethVargoMemory/memory/parallel-8            	10464970	       114.5 ns/op
BenchmarkSethVargoMemory/sweep/serial-8               	19953289	        58.98 ns/op
BenchmarkSethVargoMemory/sweep/parallel-8             	10245894	       116.1 ns/op
--- FAIL: BenchmarkSethVargoRedis
    sethvargo_test.go:101: missing REDIS_HOST
BenchmarkThrottled/memory/serial-8                    	13697444	        87.68 ns/op
BenchmarkThrottled/memory/parallel-8                  	 6532964	       183.1 ns/op
BenchmarkThrottled/sweep/serial-8                     	14031770	        85.76 ns/op
BenchmarkThrottled/sweep/parallel-8                   	 9576992	       125.2 ns/op
BenchmarkTollbooth/memory/serial-8                    	 5704026	       211.0 ns/op
BenchmarkTollbooth/memory/parallel-8                  	 3270052	       367.9 ns/op
BenchmarkTollbooth/sweep/serial-8                     	 4262370	       299.1 ns/op
BenchmarkTollbooth/sweep/parallel-8                   	 2586741	       457.4 ns/op
BenchmarkUber/memory/serial-8                         	21398766	        53.33 ns/op
BenchmarkUber/memory/parallel-8                       	 4962492	       252.1 ns/op
BenchmarkUlule/memory/serial-8                        	 7339310	       144.9 ns/op
BenchmarkUlule/memory/parallel-8                      	 8083900	       161.7 ns/op
```

If this PR interests you, you’ll want to run your own benchmarks (I didn’t bother with Redis).

And, go.mod has some unrelated changes, feel free to accept or reject. Cheers.